### PR TITLE
Added Ansible playbooks for minishift and knative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# ignore vim backup files
+*~
+# ignore ansible playbook retry files
+*.retry

--- a/playbooks/inventory
+++ b/playbooks/inventory
@@ -1,0 +1,7 @@
+[minishift:vars]
+# minishift_vm_driver=virtualbox
+minishift_memory=5GB
+minishift_isoUrl=https://zfs1.virt.gonoph.net/pulp/content/isos/minishift-centos7.iso
+
+[minishift]
+localhost

--- a/playbooks/inventory
+++ b/playbooks/inventory
@@ -1,7 +1,7 @@
 [minishift:vars]
 # minishift_vm_driver=virtualbox
 minishift_memory=5GB
-minishift_isoUrl=https://zfs1.virt.gonoph.net/pulp/content/isos/minishift-centos7.iso
+# minishift_isoUrl=https://zfs1.virt.gonoph.net/pulp/content/isos/minishift-centos7.iso
 
 [minishift]
 localhost

--- a/playbooks/roles/istio/defaults/main.yml
+++ b/playbooks/roles/istio/defaults/main.yml
@@ -1,0 +1,4 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+istio_url: https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+istio_service_type: NodePort

--- a/playbooks/roles/istio/meta/main.yml
+++ b/playbooks/roles/istio/meta/main.yml
@@ -1,0 +1,2 @@
+# vim: ts=2 sw=2 expandtab ai
+---

--- a/playbooks/roles/istio/tasks/install_istio.yml
+++ b/playbooks/roles/istio/tasks/install_istio.yml
@@ -60,5 +60,5 @@
   failed_when: "oc_cmd.rc != 0 or (oc_cmd.stdout_lines | length ) < (istio_deployments | length)"
   changed_when: false
   until: oc_cmd is successful
-  retries: 30
-  delay: 10
+  retries: "{{ (istio_wait_start.seconds / istio_wait_start.delay) | int }}"
+  delay: "{{ istio_wait_start.delay }}"

--- a/playbooks/roles/istio/tasks/install_istio.yml
+++ b/playbooks/roles/istio/tasks/install_istio.yml
@@ -1,0 +1,64 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- name: "Check if Istio is installed"
+  command: "oc get cm -n {{ istio_ns }} istio-galley-configuration"
+  register: oc_cmd
+  changed_when:
+    - oc_cmd.rc != 0
+    - errline in oc_cmd.stderr_lines
+  failed_when:
+    - oc_cmd.rc != 0
+    - errline not in oc_cmd.stderr_lines
+  vars:
+    errline: 'Error from server (NotFound): namespaces "istio-system" not found'
+
+- name: "Install latest Istio and run it in {{ istio_service_type }} mode"
+  when: oc_cmd is changed
+  shell: |
+    set -e -E
+    T=$(mktemp)
+    trap "rm -rf $T" EXIT
+    curl -L {{ istio_url }} > $T
+    sed 's/LoadBalancer/{{ istio_service_type }}/' $T | oc apply -f -
+
+- name: "update the istio-sidecar-injector configmap"
+  register: oc_cmd
+  shell: |
+    if oc get cm istio-sidecar-injector -n istio-system -o json | grep -q --color=always 'securityContext:\\n      capabilities:'
+    then
+      oc get cm istio-sidecar-injector -n istio-system -o json | sed -e 's/securityContext:\\n      capabilities:/securityContext:\\n      privileged: true\\n      capabilities:/' | oc replace -f -
+    else
+      echo ''
+    fi
+  changed_when: teststr in oc_cmd.stdout_lines
+  vars:
+    teststr: 'configmap "istio-sidecar-injector" replaced'
+
+- name: "Get list of deployments to watch"
+  command: "oc get deployment -n {{ istio_ns }} -o json"
+  changed_when: false
+  register: istio_deployments
+
+- set_fact:
+    istio_deployments: "{{ tmp['items'] | map(attribute='metadata.name') | list }}"
+  vars:
+    tmp: "{{ istio_deployments.stdout | from_json }}"
+
+- debug:
+    var: istio
+  vars:
+    istio:
+      pods: "{{ istio_deployments | length }}"
+      deployments: "{{ istio_deployments | join(', ') }}"
+      watch_cmd: "watch oc get pods -n {{ istio_ns }}"
+
+- name: "wait for istio to come up"
+  shell: |
+    oc get pods -n {{ istio_ns }} | grep Running
+  register: oc_cmd
+  failed_when: "oc_cmd.rc != 0 or (oc_cmd.stdout_lines | length ) < (istio_deployments | length)"
+  changed_when: false
+  until: oc_cmd is successful
+  retries: 30
+  delay: 10

--- a/playbooks/roles/istio/tasks/main.yml
+++ b/playbooks/roles/istio/tasks/main.yml
@@ -1,0 +1,6 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- include_tasks: update_scc.yml
+
+- include_tasks: install_istio.yml

--- a/playbooks/roles/istio/tasks/update_scc.yml
+++ b/playbooks/roles/istio/tasks/update_scc.yml
@@ -1,0 +1,20 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- name: "Get list of istio service accounts for {{ istio_scc_policy }}"
+  command: "oc get scc {{ istio_scc_policy }} -o json"
+  register: oc_cmd
+  changed_when: false
+
+- set_fact:
+    sa_found: "{{ tmp.users | select('match', ns+'.*') | map('replace', ns, '') | select('in', istio_scc_service_accounts) | list }}"
+  vars:
+    tmp: "{{ oc_cmd.stdout | from_json }}"
+    ns: "system:serviceaccount:{{ istio_ns }}:"
+
+- set_fact:
+    sa_missing: "{{ istio_scc_service_accounts | difference(sa_found) }}"
+
+- name: "Elevate missing SCCs on the service accounts in the istio-system project to {{ istio_scc_policy }}"
+  command: "oc adm policy add-scc-to-user {{ istio_scc_policy }} -z {{ item }} -n {{ istio_ns }}"
+  with_items: "{{ sa_missing }}"

--- a/playbooks/roles/istio/tasks/update_scc.yml
+++ b/playbooks/roles/istio/tasks/update_scc.yml
@@ -5,6 +5,10 @@
   command: "oc get scc {{ istio_scc_policy }} -o json"
   register: oc_cmd
   changed_when: false
+  until: oc_cmd is successful
+  retries: 20
+  delay: 3
+
 
 - set_fact:
     sa_found: "{{ tmp.users | select('match', ns+'.*') | map('replace', ns, '') | select('in', istio_scc_service_accounts) | list }}"

--- a/playbooks/roles/istio/vars/main.yml
+++ b/playbooks/roles/istio/vars/main.yml
@@ -1,5 +1,8 @@
 # vim: ts=2 sw=2 expandtab ai
 ---
+istio_wait_start:
+  seconds: 600
+  delay: 10
 istio_ns: istio-system
 istio_scc_policy: anyuid
 istio_scc_service_accounts:

--- a/playbooks/roles/istio/vars/main.yml
+++ b/playbooks/roles/istio/vars/main.yml
@@ -1,0 +1,17 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+istio_ns: istio-system
+istio_scc_policy: anyuid
+istio_scc_service_accounts:
+  - istio-ingress-service-account
+  - default
+  - prometheus
+  - istio-egressgateway-service-account
+  - istio-citadel-service-account
+  - istio-ingressgateway-service-account
+  - istio-cleanup-old-ca-service-account
+  - istio-mixer-post-install-account
+  - istio-mixer-service-account
+  - istio-pilot-service-account
+  - istio-sidecar-injector-service-account
+  - istio-galley-service-account

--- a/playbooks/roles/knative/defaults/main.yml
+++ b/playbooks/roles/knative/defaults/main.yml
@@ -1,0 +1,5 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+knative_url: https://storage.googleapis.com/knative-releases/serving/latest/release-lite.yaml
+knative_service_type: NodePort

--- a/playbooks/roles/knative/meta/main.yml
+++ b/playbooks/roles/knative/meta/main.yml
@@ -1,0 +1,2 @@
+# vim: ts=2 sw=2 expandtab ai
+---

--- a/playbooks/roles/knative/tasks/install_knative.yml
+++ b/playbooks/roles/knative/tasks/install_knative.yml
@@ -1,0 +1,51 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- name: "Check if knative is installed"
+  command: "oc get cm -n knative-build config-logging"
+  register: oc_cmd
+  changed_when:
+    - oc_cmd.rc != 0
+    - errline in oc_cmd.stderr_lines
+  failed_when:
+    - oc_cmd.rc != 0
+    - errline not in oc_cmd.stderr_lines
+  vars:
+    errline: 'Error from server (NotFound): namespaces "knative-build" not found'
+
+- name: "Install latest knative and run it in {{ knative_service_type }} mode"
+  when: oc_cmd is changed
+  shell: |
+    set -e -E
+    T=$(mktemp)
+    trap "rm -rf $T" EXIT
+    curl -L {{ knative_url }} > $T
+    sed 's/LoadBalancer/{{ knative_service_type }}/' $T | oc apply -f -
+
+- name: "Get list of deployments to watch"
+  command: "oc get deployment -n knative-serving -o json"
+  changed_when: false
+  register: knative_deployments
+
+- set_fact:
+    knative_deployments: "{{ tmp['items'] | map(attribute='metadata.name') | list }}"
+  vars:
+    tmp: "{{ knative_deployments.stdout | from_json }}"
+
+- debug:
+    var: knative
+  vars:
+    knative:
+      pods: "{{ knative_deployments | length }}"
+      deployments: "{{ knative_deployments | join(', ') }}"
+      watch_cmd: "watch oc get pods -n knative-serving"
+
+- name: "wait for knative to come up"
+  shell: |
+    oc get pods -n knative-serving | grep Running
+  register: oc_cmd
+  failed_when: "oc_cmd.rc != 0 or (oc_cmd.stdout_lines | length ) < (knative_deployments | length)"
+  changed_when: false
+  until: oc_cmd is successful
+  retries: 30
+  delay: 10

--- a/playbooks/roles/knative/tasks/install_knative.yml
+++ b/playbooks/roles/knative/tasks/install_knative.yml
@@ -47,5 +47,5 @@
   failed_when: "oc_cmd.rc != 0 or (oc_cmd.stdout_lines | length ) < (knative_deployments | length)"
   changed_when: false
   until: oc_cmd is successful
-  retries: 30
-  delay: 10
+  retries: "{{ (knative_wait_start.seconds / knative_wait_start.delay) | int }}"
+  delay: "{{ knative_wait_start.delay }}"

--- a/playbooks/roles/knative/tasks/main.yml
+++ b/playbooks/roles/knative/tasks/main.yml
@@ -1,0 +1,8 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- include_tasks: update_scc.yml
+
+- include_tasks: update_cluster_roles.yml
+
+- include_tasks: install_knative.yml

--- a/playbooks/roles/knative/tasks/update_cluster_roles.yml
+++ b/playbooks/roles/knative/tasks/update_cluster_roles.yml
@@ -1,0 +1,25 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- name: "get cluster roles"
+  command: "oc get clusterrolebindings -o json"
+  register: oc_cmd
+  changed_when: false
+
+- name: "filter cluster roles by service account"
+  set_fact:
+    subjects: "{{ tmp['items'] | selectattr('roleRef.name', 'eq', 'cluster-admin') | map(attribute='subjects') | flatten | selectattr('kind', 'eq', 'ServiceAccount') | list }}"
+  vars:
+    tmp: "{{ oc_cmd.stdout | from_json }}"
+
+- name: "found service accounts with cluster roles"
+  set_fact:
+    sa_found: "{{ subjects | to_json | from_json | json_query('[*].join(`:`,[`system`,`serviceaccount`,namespace,name ])') | select('in', knative_cluster_accounts) | list }}"
+
+- name: "service accounts missing cluster roles"
+  set_fact:
+    sa_missing: "{{ knative_cluster_accounts | difference(sa_found) }}"
+
+- name: "Add cluster role"
+  command: "oc adm policy add-cluster-role-to-user cluster-admin {{ item }}"
+  with_items: "{{ sa_missing }}"

--- a/playbooks/roles/knative/tasks/update_scc.yml
+++ b/playbooks/roles/knative/tasks/update_scc.yml
@@ -1,0 +1,21 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- name: "Get list of knative service accounts for {{ knative_scc_policy }}"
+  command: "oc get scc {{ knative_scc_policy }} -o json"
+  register: oc_cmd
+  changed_when: false
+
+- name: "filter users by knative service accounts"
+  set_fact:
+    sa_found: "{{ tmp.users | select('in', knative_scc_service_accounts) | list }}"
+  vars:
+    tmp: "{{ oc_cmd.stdout | from_json }}"
+
+- name: "find service accounts with missing scc"
+  set_fact:
+    sa_missing: "{{ knative_scc_service_accounts | difference(sa_found) }}"
+
+- name: "Elevate missing SCCs on the service accounts for knativeproject to {{ knative_scc_policy }}"
+  command: "oc adm policy add-scc-to-user {{ knative_scc_policy }} {{ item }}"
+  with_items: "{{ sa_missing }}"

--- a/playbooks/roles/knative/vars/main.yml
+++ b/playbooks/roles/knative/vars/main.yml
@@ -1,0 +1,16 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+knative_scc_policy: anyuid
+knative_scc_service_accounts:
+  - system:serviceaccount:knative-build:build-controller
+  - system:serviceaccount:knative-serving:controller
+  - system:serviceaccount:knative-serving:autoscaler
+  - system:serviceaccount:monitoring:kube-state-metrics
+  - system:serviceaccount:monitoring:node-exporter
+  - system:serviceaccount:monitoring:prometheus-system
+
+knative_cluster_policy: cluster-admin
+knative_cluster_accounts:
+  - system:serviceaccount:knative-build:build-controller
+  - system:serviceaccount:knative-serving:controller

--- a/playbooks/roles/knative/vars/main.yml
+++ b/playbooks/roles/knative/vars/main.yml
@@ -1,6 +1,8 @@
 # vim: ts=2 sw=2 expandtab ai
 ---
-
+knative_wait_start:
+  seconds: 60
+  delay: 10
 knative_scc_policy: anyuid
 knative_scc_service_accounts:
   - system:serviceaccount:knative-build:build-controller

--- a/playbooks/roles/minishift/defaults/main.yml
+++ b/playbooks/roles/minishift/defaults/main.yml
@@ -1,0 +1,11 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+minishift_profile: knative
+minishift_memory: 6GB
+minishift_cpus: "4"
+minishift_imageCaching: 'true'
+minishift_isoUrl: ''
+minishift_addons: admin-user,anyuid
+minishift_log_dir: /tmp/minishift_logs
+minishift_log_dir_console: "{{ minishift_log_dir }}/console.log"
+minishift_user: docker

--- a/playbooks/roles/minishift/handlers/main.yml
+++ b/playbooks/roles/minishift/handlers/main.yml
@@ -1,0 +1,14 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: minishift stop
+  shell: "minishift stop"
+
+- name: minishift delete
+  shell: "minishift delete -f"
+
+- listen: minishift start
+  debug:
+    msg: "Starting minishift - look in {{ minishift_log_dir_console }}"
+
+- name: minishift start
+  shell: "minishift --log_dir {{ minishift_log_dir }} start | tee {{ minishift_log_dir_console }}"

--- a/playbooks/roles/minishift/meta/main.yml
+++ b/playbooks/roles/minishift/meta/main.yml
@@ -1,0 +1,2 @@
+# vim: ts=2 sw=2 expandtab ai
+---

--- a/playbooks/roles/minishift/tasks/inject_hosts.yml
+++ b/playbooks/roles/minishift/tasks/inject_hosts.yml
@@ -4,12 +4,14 @@
 - name: determine cluster ip
   command: minishift ip
   register: cluster_ip
+  changed_when: false
 
 - name: "ssh_key: get machine path"
   shell: |
     eval $(minishift docker-env)
     ls $DOCKER_CERT_PATH/../machines/knative/id_rsa
   register: cluster_sshkey
+  changed_when: false
 
 - name: set variables
   set_fact:

--- a/playbooks/roles/minishift/tasks/inject_hosts.yml
+++ b/playbooks/roles/minishift/tasks/inject_hosts.yml
@@ -1,0 +1,27 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+
+- name: determine cluster ip
+  command: minishift ip
+  register: cluster_ip
+
+- name: "ssh_key: get machine path"
+  shell: |
+    eval $(minishift docker-env)
+    ls $DOCKER_CERT_PATH/../machines/knative/id_rsa
+  register: cluster_sshkey
+
+- name: set variables
+  set_fact:
+    cluster_ip: "{{ cluster_ip.stdout | ipaddr('address') }}"
+    cluster_sshkey: "{{ cluster_sshkey.stdout | realpath }}"
+
+- name: add cluster host
+  add_host:
+    name: "{{ minishift_profile }}"
+    groups:
+      - cluster
+    ansible_user: "{{ minishift_user }}"
+    ansible_ssh_private_key_file: "{{ cluster_sshkey }}"
+    ansible_host: "{{ cluster_ip }}"
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"

--- a/playbooks/roles/minishift/tasks/main.yml
+++ b/playbooks/roles/minishift/tasks/main.yml
@@ -1,0 +1,7 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- include_tasks: version_check.yml
+
+- include_tasks: minishift_start.yml
+
+- include_tasks: inject_hosts.yml

--- a/playbooks/roles/minishift/tasks/minishift_start.yml
+++ b/playbooks/roles/minishift/tasks/minishift_start.yml
@@ -1,0 +1,65 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: ensure log dir exists
+  file:
+    path: "{{ minishift_log_dir }}"
+    state: directory
+
+- name: "check for profile: {{ minishift_profile }}"
+  shell: |
+    PROFILE=$(minishift profile list | grep '^- {{ minishift_profile }}\t')
+    ACTIVE=$(grep '(Active)' <<< "$PROFILE")
+    test "x$ACTIVE" == "x" && minishift profile set {{ minishift_profile }} || echo ""
+  register: cmd
+  changed_when: cmd.stdout | length > 0
+  notify:
+    - minishift stop
+    - minishift delete
+    - minishift start
+
+- name: set config
+  shell: |
+    CPUS=$(minishift config get {{ item.name }} | sed 's/^<nil>$//')
+    test "x$CPUS" == "x{{ item.value }}" && echo "" || {{ command }}
+  register: cmd
+  changed_when: cmd.stdout | length > 0
+  vars:
+    command: "{{ (item.value | length > 0) | ternary('minishift config set '+item.name+' '+item.value,'minishift config unset '+item.name) }}"
+  with_items:
+    - name: memory
+      value: "{{ minishift_memory }}"
+    - name: cpus
+      value: "{{ minishift_cpus }}"
+    - name: image-caching
+      value: "{{ minishift_imageCaching }}"
+    - name: iso-url
+      value: "{{ minishift_isoUrl }}"
+  notify:
+    - minishift stop
+    - minishift delete
+    - minishift start
+
+- name: "set addons: {{ minishift_addons }}"
+  shell: |
+    ALL=$(minishift addon list | cut -b 3-)
+    ENABLED=$( grep ': enabled' <<< "$ALL" | cut -d ' ' -f 1)
+    DISABLED=$( grep ': disabled' <<< "$ALL" | cut -d ' ' -f 1)
+    grep -vf <(echo "{{ ADDONS }}") <<< "$ENABLED" | xargs -n 1 minishift addon disable
+    grep -f <(echo "{{ ADDONS }}") <<< "$DISABLED" | xargs -n 1 minishift addon enable
+  args:
+    executable: /bin/bash
+  vars:
+    ADDONS: "{{ minishift_addons.split(',') | join('\n') }}"
+  register: cmd
+  changed_when: cmd.stdout | length > 0
+  notify:
+    - minishift stop
+    - minishift delete
+    - minishift start
+
+- name: Ensure minishift starts
+  command: "true"
+  notify:
+    - minishift start
+
+- meta: flush_handlers

--- a/playbooks/roles/minishift/tasks/version_check.yml
+++ b/playbooks/roles/minishift/tasks/version_check.yml
@@ -1,0 +1,15 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: "Get minishift version"
+  command: minishift version
+  register: minishift_version
+  changed_when: "(minishift_version.stdout_lines.0.split(' '))[1][1:] is version(minishift_min_version, '<')"
+
+- name: Validate minishift version
+  assert:
+    msg:
+      required_version: "{{ minishift_min_version }}"
+      how_to_resolve: "minishift update"
+    that:
+      - minishift_version is success
+      - minishift_version is not changed

--- a/playbooks/roles/minishift/vars/main.yml
+++ b/playbooks/roles/minishift/vars/main.yml
@@ -1,0 +1,3 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+minishift_min_version: "1.23.0+91235ee"

--- a/playbooks/roles/prepare/default/main.yml
+++ b/playbooks/roles/prepare/default/main.yml
@@ -1,0 +1,2 @@
+# vim: ts=2 sw=2 expandtab ai
+---

--- a/playbooks/roles/prepare/handlers/main.yml
+++ b/playbooks/roles/prepare/handlers/main.yml
@@ -1,0 +1,15 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: restart api
+  connection: smart
+  shell: |
+    docker stop $(docker ps -l -q --filter "label=io.kubernetes.container.name=api")
+
+- name: wait for api
+  listen: restart api
+  command: oc get projects
+  connection: local
+  register: cmd
+  until: cmd is successful
+  retries: 30
+  delay: 10

--- a/playbooks/roles/prepare/meta/main.yml
+++ b/playbooks/roles/prepare/meta/main.yml
@@ -1,0 +1,2 @@
+# vim: ts=2 sw=2 expandtab ai
+---

--- a/playbooks/roles/prepare/tasks/knative_patch.yml
+++ b/playbooks/roles/prepare/tasks/knative_patch.yml
@@ -1,0 +1,22 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: "knative: read in file"
+  connection: smart
+  command: "cat {{ knative_patch.file }}"
+  changed_when: false
+  register: command_out
+
+- set_fact:
+    patch_to: "{{ patch_from | combine( dict([[knative_patch.key, knative_patch.value]] ) ) }}"
+  vars:
+    patch_from: "{{ command_out.stdout | from_yaml }}"
+
+- name: "knative: patch file"
+  connection: smart
+  copy:
+    dest: "{{ knative_patch.file }}"
+    content: "{{ patch_to | to_yaml }}"
+  notify:
+    - restart api
+
+- meta: flush_handlers

--- a/playbooks/roles/prepare/tasks/main.yml
+++ b/playbooks/roles/prepare/tasks/main.yml
@@ -1,0 +1,5 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- include_tasks: knative_patch.yml
+
+- include_tasks: myproject-istio.yml

--- a/playbooks/roles/prepare/tasks/myproject-istio.yml
+++ b/playbooks/roles/prepare/tasks/myproject-istio.yml
@@ -1,0 +1,35 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: login as admin
+  command: oc login -u admin -p admin
+  changed_when: false
+
+- name: Change project to myproject
+  command: "oc project myproject"
+  register: oc_cmd
+  changed_when: errstr not in oc_cmd.stdout
+  vars:
+    errstr: 'Already on project'
+
+- name: Assign privileged SCC to the default SA in myproject
+  command: "oc adm policy add-scc-to-user privileged -z default"
+  changed_when: false
+
+- name: Enable istio-injection on myproject by adding a label to the project
+  command: "oc label namespace myproject istio-injection=enabled"
+  register: oc_cmd
+  changed_when:
+    - oc_cmd.rc == 0
+  failed_when:
+    - oc_cmd.rc != 0
+    - errstr not in oc_cmd.stderr
+  vars:
+    errstr: "error: 'istio-injection' already has a value"
+
+- name: oc get ns myproject --show-labels
+  command: "oc get ns myproject --show-labels"
+  register: oc_cmd
+  changed_when: false
+
+- debug:
+    var: oc_cmd.stdout_lines

--- a/playbooks/roles/prepare/vars/main.yml
+++ b/playbooks/roles/prepare/vars/main.yml
@@ -1,0 +1,18 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+knative_patch:
+  file: /var/lib/minishift/base/kube-apiserver/master-config.yaml
+  key: admissionConfig
+  value: 
+    pluginConfig:
+      MutatingAdmissionWebhook:
+        configuration:
+          apiVersion: v1
+          disable: false
+          kind: DefaultAdmissionConfig
+      ValidatingAdmissionWebhook:
+        configuration:
+          apiVersion: v1
+          disable: false
+          kind: DefaultAdmissionConfig
+

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,0 +1,30 @@
+# vim: ts=2 sw=2 expandtab ai
+---
+- name: Create minishift instance
+  any_errors_fatal: true
+  force_handlers: true
+  hosts: minishift
+  gather_facts: false
+  connection: local
+  roles:
+    - minishift
+
+- name: Test openshift node
+  any_errors_fatal: true
+  force_handlers: true
+  hosts: cluster
+  gather_facts: false
+  connection: smart
+  tasks:
+    - ping:
+
+- name: Install knative
+  any_errors_fatal: true
+  force_handlers: true
+  hosts: cluster
+  gather_facts: false
+  connection: local
+  roles:
+    - prepare
+    - istio
+    - knative


### PR DESCRIPTION
These sets of patches add Ansible playbooks and roles to install knative on Minishift. It's based on the instructions you laid out as of September 12th, 2018.

Currently, it's crafted in such a way so that other ways of creating the cluster can **eventually** be supported such as:

* minikube
* oc cluster up
* minishift using the `generic` vm-driver

TODO:

* Create a README.md describing the inventory and variables.
* Added support for other cluster creation implementations.